### PR TITLE
Feature | Ignore mock folder contracts npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "4.7.2",
   "files": [
     "/contracts/**/*.sol",
-    "!/contracts/mocks/**/*",
+    "!/contracts/mocks/**",
     "!/contracts/token/ERC721/artifacts/**/*"
   ],
   "scripts": {


### PR DESCRIPTION
Publishing following package.json results in following [package](https://unpkg.com/browse/erc721-f-testing-publish@4.7.3/). 
Previous link may not fully work due to the published testing package being instantly removed.

![image](https://user-images.githubusercontent.com/79218348/205269746-7b7a695f-5aa7-4514-adc7-0d32b2fc749e.png)
