### PR TITLE
No need to base64-encode the output of tokenURI

### DIFF
--- a/contracts/token/ERC721/extensions/ERC721FOnChain.sol
+++ b/contracts/token/ERC721/extensions/ERC721FOnChain.sol
@@ -37,20 +37,18 @@ abstract contract ERC721FOnChain is IERC4883, ERC721F {
         string memory svgData = renderTokenById(tokenId);
         string memory traits = getTraits(tokenId);
         return string(
-                    abi.encodePacked(
-                        'data:application/json;utf-8,{"name": "',
-                        name(),
-                        " #",
-                        Strings.toString(tokenId),
-                        '", "description": "',
-                        getDescription(),
-                        '", "image": "data:image/svg+xml;base64,',
-                        Base64.encode(bytes(svgData)),
-                        bytes(traits).length == 0 ? '"' : '", "attributes": ',
-                        traits,
-                        "}"
-                    )
-                )
+            abi.encodePacked(
+                'data:application/json;utf-8,{"name": "',
+                name(),
+                " #",
+                Strings.toString(tokenId),
+                '", "description": "',
+                getDescription(),
+                '", "image": "data:image/svg+xml;base64,',
+                Base64.encode(bytes(svgData)),
+                bytes(traits).length == 0 ? '"' : '", "attributes": ',
+                traits,
+                "}"
             )
         );
     }

--- a/contracts/token/ERC721/extensions/ERC721FOnChain.sol
+++ b/contracts/token/ERC721/extensions/ERC721FOnChain.sol
@@ -36,11 +36,9 @@ abstract contract ERC721FOnChain is IERC4883, ERC721F {
         require(_exists(tokenId), "Non-Existing token");
         string memory svgData = renderTokenById(tokenId);
         string memory traits = getTraits(tokenId);
-        string memory json = Base64.encode(
-            bytes(
-                string(
+        return string(
                     abi.encodePacked(
-                        '{"name": "',
+                        'data:application/json;utf-8,{"name": "',
                         name(),
                         " #",
                         Strings.toString(tokenId),
@@ -55,7 +53,6 @@ abstract contract ERC721FOnChain is IERC4883, ERC721F {
                 )
             )
         );
-        return string(abi.encodePacked("data:application/json;base64,", json));
     }
 
     /**


### PR DESCRIPTION
Saves gas to do it this way which could be relevant for huge on-chain files / complicated generations.