### PR TITLE
Feature - Batch mint

### DIFF
--- a/contracts/token/ERC721/ERC721F.sol
+++ b/contracts/token/ERC721/ERC721F.sol
@@ -19,9 +19,10 @@ contract ERC721F is Ownable, ERC721 {
     // Base URI for Meta data
     string private _baseTokenURI;
 
-    constructor(string memory name_, string memory symbol_)
-        ERC721(name_, symbol_)
-    {}
+    constructor(
+        string memory name_,
+        string memory symbol_
+    ) ERC721(name_, symbol_) {}
 
     /**
      * @dev walletofOwner
@@ -29,12 +30,9 @@ contract ERC721F is Ownable, ERC721 {
      * This read function is O(totalSupply). If calling from a separate contract, be sure to test gas first.
      * It may also degrade with extremely large collection sizes (e.g >> 10000), test for your use case.
      */
-    function walletOfOwner(address _owner)
-        external
-        view
-        virtual
-        returns (uint256[] memory)
-    {
+    function walletOfOwner(
+        address _owner
+    ) external view virtual returns (uint256[] memory) {
         uint256 ownerTokenCount = balanceOf(_owner);
         uint256[] memory ownedTokenIds = new uint256[](ownerTokenCount);
         uint256 currentTokenId = _startTokenId();
@@ -42,7 +40,7 @@ contract ERC721F is Ownable, ERC721 {
         uint256 tokenSupply = _tokenSupply;
 
         unchecked {
-            for(;;) {
+            for (;;) {
                 if (ownedTokenIndex >= ownerTokenCount) {
                     break;
                 }
@@ -91,6 +89,21 @@ contract ERC721F is Ownable, ERC721 {
         super._mint(to, tokenId);
         unchecked {
             _tokenSupply++;
+        }
+    }
+
+    function _batchMint(
+        address to,
+        uint256 startIndex,
+        uint256 amount
+    ) internal virtual {
+        require(amount > 0, "Must mint at least 1 token");
+        unchecked {
+            for (uint256 i; i < amount; ) {
+                super._mint(to, startIndex + i);
+                i++;
+            }
+            _tokenSupply += amount;
         }
     }
 

--- a/contracts/token/ERC721/ERC721F.sol
+++ b/contracts/token/ERC721/ERC721F.sol
@@ -19,10 +19,9 @@ contract ERC721F is Ownable, ERC721 {
     // Base URI for Meta data
     string private _baseTokenURI;
 
-    constructor(
-        string memory name_,
-        string memory symbol_
-    ) ERC721(name_, symbol_) {}
+    constructor(string memory name_, string memory symbol_)
+        ERC721(name_, symbol_)
+    {}
 
     /**
      * @dev walletofOwner
@@ -30,9 +29,12 @@ contract ERC721F is Ownable, ERC721 {
      * This read function is O(totalSupply). If calling from a separate contract, be sure to test gas first.
      * It may also degrade with extremely large collection sizes (e.g >> 10000), test for your use case.
      */
-    function walletOfOwner(
-        address _owner
-    ) external view virtual returns (uint256[] memory) {
+    function walletOfOwner(address _owner)
+        external
+        view
+        virtual
+        returns (uint256[] memory)
+    {
         uint256 ownerTokenCount = balanceOf(_owner);
         uint256[] memory ownedTokenIds = new uint256[](ownerTokenCount);
         uint256 currentTokenId = _startTokenId();

--- a/contracts/token/ERC721/ERC721F.sol
+++ b/contracts/token/ERC721/ERC721F.sol
@@ -94,6 +94,10 @@ contract ERC721F is Ownable, ERC721 {
         }
     }
 
+    /**
+     * @dev Mints `amount` tokens starting from `startIndex` and transfers them to `to`
+     * @dev Requires that `amount` is larger than one
+     */
     function _batchMint(
         address to,
         uint256 startIndex,


### PR DESCRIPTION
Gas differences when using the batch mint instead of the single mint with a for loop

| _batchMint vs _mint in for-loop 	| Mint 1 	| Mint 10 	| Mint 100 	|
|---------------------------------	|--------	|---------	|---------- 	|
| No Runs                         	        | 11     	| -2.428  	| -26.818  	|
| 100 Runs                        	        | 16     	| -2.225  	| -24.635  	|
| 1000 Runs                       	        | 16     	| -2.225  	| -24.635  	|

Tests were done with by altering the mint function of ERC721FGasReporterMock.sol to 
```
function mint(address to, uint256 numberOfTokens) internal {
        _batchMint(to, _totalMinted(), numberOfTokens);
}
```