### PR TITLE
Fix | Verify contracts on compile

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -28,9 +28,10 @@ subtask(
             ) {
                 return false;
             } else if (process.env.WHITELIST_PATH) {
+                const paths = process.env.WHITELIST_PATH.split(" ");
                 return (
-                    relativePath === process.env.WHITELIST_PATH ||
-                    solidityFilePath === process.env.WHITELIST_PATH
+                    paths.includes(relativePath) ||
+                    paths.includes(solidityFilePath)
                 );
             } else {
                 return true;

--- a/scripts/sh/verify-contract.sh
+++ b/scripts/sh/verify-contract.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-filter="$1"
+filter="${@:1}"
 
 if [[ $filter != *.sol ]]; then
     echo "Invalid filepath. It must end with '.sol'."


### PR DESCRIPTION
Now takes all arguments passed to verify-contract and passes them onto hardhat compile

hardhat compile now supports multiple contract paths as long as they're spaced by ` ` in the `WHITELIST_PATH`