### PR TITLE
ci: remove pull_request_target trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,56 +1,56 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  pull_request_target:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+    pull_request_target:
+        branches: [main]
 
 jobs:
-  hardhat:
-    name: Hardhat Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+    hardhat:
+        name: Hardhat Tests
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: ".nvmrc"
 
-      - name: Install dependencies
-        run: npm ci
+            - name: Install dependencies
+              run: npm ci
 
-      - name: Rewrite example imports for local dev
-        run: npm run update-example-imports:dev
+            - name: Rewrite example imports for local dev
+              run: npm run update-example-imports:dev
 
-      - name: Compile contracts
-        run: npx hardhat compile
+            - name: Compile contracts
+              run: npx hardhat compile
 
-      - name: Run tests
-        run: npm test
+            - name: Run tests
+              run: npm test
 
-  foundry:
-    name: Foundry Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+    foundry:
+        name: Foundry Tests
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v7
 
-      - name: Install Node dependencies (required for remappings)
-        run: npm ci
+            - name: Install Node dependencies (required for remappings)
+              run: npm ci
 
-      - name: Rewrite example imports for local dev
-        run: npm run update-example-imports:dev
+            - name: Rewrite example imports for local dev
+              run: npm run update-example-imports:dev
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+            - name: Install Foundry
+              uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Build contracts
-        run: forge build
+            - name: Build contracts
+              run: forge build
 
-      - name: Run tests
-        run: forge test
+            - name: Run tests
+              run: forge test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
         branches: [main]
     pull_request:
         branches: [main]
-    pull_request_target:
-        branches: [main]
 
 jobs:
     hardhat:


### PR DESCRIPTION
## Why

Every PR currently runs CI twice, and the extra `pull_request_target` run is worse than useless:

- **Misleading green**: `actions/checkout` with no `ref` under `pull_request_target` checks out the **base** branch, so those "Hardhat Tests" / "Foundry Tests" checks test `main`, not the PR. Observed on dependabot PR #140: the real `pull_request` run failed `npm ci` (ERESOLVE) while the `pull_request_target` run passed.
- **Security hazard**: `pull_request_target` runs fork PRs with secrets and a write token. Today it's "safe but useless"; if anyone later adds `ref: ${{ github.event.pull_request.head.sha }}` to the checkout it becomes remote code execution with secrets for any fork PR.
- **Cost**: doubles CI minutes per PR for no signal.

## What

- `style(ci)`: format `ci.yml` with the repo's own `.prettierrc` (tabWidth 4, double quotes) — the checked-in file didn't conform; no functional change (kept separate from the fix).
- `ci`: drop the `pull_request_target` trigger block. `push` (main) and `pull_request` remain and cover everything, including dependabot PRs (same-repo branches).

Functional diff: 2 deleted lines.

## Verification

- `prettier --check .github/workflows/ci.yml` passes (parses + conforms).
- Triggers after change: `push` (main), `pull_request` (main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)