### PR TITLE
ci(dependabot): group rocketh updates and add 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,19 @@
 version: 2
 
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: "deps"
+    # Enable version updates for npm
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      open-pull-requests-limit: 10
+      commit-message:
+          prefix: "deps"
 
-  # Enable version updates for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "ci"
+    # Enable version updates for GitHub Actions
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      commit-message:
+          prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,17 @@ updates:
       open-pull-requests-limit: 10
       commit-message:
           prefix: "deps"
+      # Supply-chain gate: only propose releases at least 7 days old.
+      # Also prevents rebases from retargeting to fresh releases.
+      cooldown:
+          default-days: 7
+      # The rocketh monorepo family releases in lockstep; one grouped PR
+      # instead of five lockfile-conflicting ones.
+      groups:
+          rocketh:
+              patterns:
+                  - "rocketh"
+                  - "@rocketh/*"
 
     # Enable version updates for GitHub Actions
     - package-ecosystem: "github-actions"
@@ -20,3 +31,5 @@ updates:
           interval: "weekly"
       commit-message:
           prefix: "ci"
+      cooldown:
+          default-days: 7


### PR DESCRIPTION
## Why

Two lessons from today's dependabot batch:

1. **The five rocketh monorepo packages release in lockstep** (all published within seconds of each other), but arrive as five separate PRs that share the root `package-lock.json` — so merging them means five serial dependabot-rebase + CI cycles.
2. **Rebases silently retarget to the newest release.** #143 was vetted at rocketh 0.19.9 (18 days old) but after dependabot's rebase it merged **0.19.10, published 3 days ago** — inside the 7-day supply-chain window — and had to be reverted (4f71ed6). The three remaining rocketh PRs (#145/#146/#148) were caught doing the same and are on hold until 12-08.

## What

- `groups.rocketh` (patterns `rocketh`, `@rocketh/*`): one grouped PR for the whole family.
- `cooldown.default-days: 7` on both ecosystems: dependabot itself won't propose (or retarget to) releases younger than 7 days — the manual merge-time age check becomes a backstop instead of the only line of defense.

Functional diff: 13 added lines (plus a separate formatting-only commit aligning the file with the repo's `.prettierrc`).

## Verification

- `prettier --check` passes.
- After merging, confirm the config parses under **Insights → Dependency graph → Dependabot** (GitHub validates on push).
- Existing open PRs are unaffected until the next scheduled run, which should regroup/supersede #145/#146/#148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)