### PR TITLE
docs: fix stale facts found in the documentation audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-03-24 08:45:09 CET
-**Commit:** f394aab
+**Reviewed:** 2026-08-08
+**Commit:** d8b69f0
 **Branch:** main
 
 ## OVERVIEW
@@ -17,7 +17,7 @@ ERC721F is a gas-optimized ERC721 implementation (Solidity 0.8.24, OpenZeppelin 
 ├── examples/         # reference/example implementations
 │   └── EIP-2535/     # isolated npm workspace
 ├── scripts/          # helper scripts (env/import/snapshot tooling)
-├── docs/             # reference data/presentations (non-build assets)
+├── docs/             # migration notes (md) + reference data/presentations
 └── lib/              # vendored dependencies (exclude from ownership scans)
 ```
 
@@ -71,12 +71,17 @@ High-centrality modules:
 
 ```bash
 # Root toolchain
-npm install
+npm ci                                # CI parity (npm install also works)
 npx hardhat compile
 npx hardhat test
 npx hardhat test --coverage
 forge build
 forge test
+
+# Lint / format
+npm run lint                          # solhint over all .sol files
+npm run lint:foundry                  # solhint with the foundry-test config
+npm run prettier:solidity             # prettier + solidity plugin, writes in place
 
 # Focused execution
 npx hardhat compile contracts/token/ERC721/ERC721F.sol
@@ -94,6 +99,7 @@ npm run update-example-imports:prod
 
 ## NOTES
 
-- If Hardhat example compilation fails on `@franknft.eth/erc721-f` imports, switch examples to local relative imports for local testing.
-- `examples/EIP-2535` has independent config and should be run as its own workspace (`npm run <script> --workspace=eip-2535` or from that folder directly).
-- `docs/` is reference material (xlsx/pdf/png), not part of compile/test pipeline.
+- If Hardhat example compilation fails on `@franknft.eth/erc721-f` imports, run `npm run update-example-imports:dev` to rewrite them to local paths (`:prod` restores the published form). CI runs `:dev` in both jobs before compiling.
+- `examples/EIP-2535` has independent config; run it via `npm run <script> --workspace=eip-2535` or from that folder. Note the root `npm test` also exercises it: `test/hardhat/examples/EIP-2535.test.js` shells out to the workspace suite.
+- CI is `.github/workflows/ci.yml`: two jobs ("Hardhat Tests", "Foundry Tests"), both `npm ci` + `update-example-imports:dev` first; triggers are push and pull_request on main only.
+- `docs/` is reference material (md/xlsx/pdf/png), not part of compile/test pipeline.

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -4,6 +4,8 @@ Measured gas consumption of **ERC721F** compared to **OpenZeppelin ERC721 + ERC7
 
 All figures are Foundry measurements at identical conditions. Hardhat numbers are cross-validated and match.
 
+> Benchmark figures date from 2026-05-18. The Foundry toolchain and solc settings are unchanged since, so the numbers remain representative; the Hardhat cross-validation predates the Hardhat 3 migration and has not been re-run.
+
 ---
 
 ## Environment
@@ -139,7 +141,7 @@ meaningful mint volume the per-mint savings recoup the extra deploy gas within t
 ### Prerequisites
 
 ```bash
-# Node.js >= 18
+# Node.js >= 24 (see .nvmrc)
 npm install
 
 # Foundry
@@ -175,12 +177,11 @@ forge test --gas-report --match-path "test/foundry/token/ERC721/OZErc721GasCompa
 ### Foundry — both side by side
 
 ```bash
-forge test --gas-report \
-  --match-path "test/foundry/token/ERC721/ERC721FGasReporterMock.t.sol" \
-  --match-path "test/foundry/token/ERC721/OZErc721GasComparison.t.sol"
+forge test --gas-report --match-path "test/foundry/token/ERC721/ERC721FGasReporterMock.t.sol"
+forge test --gas-report --match-path "test/foundry/token/ERC721/OZErc721GasComparison.t.sol"
 ```
 
-> Note: `--match-path` only accepts one path at a time in Foundry. Run both commands separately and
+> Note: `--match-path` only accepts one path at a time in Foundry, so run the two commands separately and
 > compare the two `╭─…─╮` tables.
 
 ### Hardhat — ERC721F gas report
@@ -198,9 +199,15 @@ Edit `hardhat.config.js`:
 
 ```js
 solidity: {
-  optimizer: {
-    enabled: true,
-    runs: 1000   // ← change this; higher = cheaper runtime, more expensive deploy
+  profiles: {
+    default: {
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 1000 // ← change this; higher = cheaper runtime, more expensive deploy
+        }
+      }
+    }
   }
 }
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,9 @@ Don't forget to give the project a star! Thanks again!
 4. `npx hardhat compile`
 5. `npx hardhat test`
 
-> **Warning**
-> When running any test of a contract located in /examples, you'll receive a compilation error due to the @franknft.eth/erc721-f library not being installed.
-> To prevent this error you must change all imports where @franknft.eth/erc721-f to the location of the local file. For example "../contracts/utils/AllowList.sol" in the AllowList example.
-
-> **Warning**
-> Since hardhat only compiles a single path at once, you'll probably fail every single test that's executed on solutions located in /examples. This is because those artifacts haven't been created yet.
-> These can be created by changing the the sources path in hardhat.config.js to "./examples" and executing step 3 again.
+> **Note**
+> Contracts in /examples import the published `@franknft.eth/erc721-f` package. Before compiling or testing them locally, run `npm run update-example-imports:dev` to rewrite those imports to local paths (CI does the same in both jobs); `npm run update-example-imports:prod` restores the published form. The pre-commit hook keeps committed files in the published form.
+> The root Hardhat config compiles `contracts/` and `examples/` together in one run, so no config changes are needed.
 
 **Note:** `npx hardhat clean` removes the created artifacts
 
@@ -40,7 +36,7 @@ Don't forget to give the project a star! Thanks again!
 
 - Generate a gas report with Hardhat 3's built-in flag: `npx hardhat test --gas-stats`
 - Write the report to a JSON file with `npx hardhat test --gas-stats-json <path>`
-- Change the total runs and toggle the optimizer by changing the `solidity` `optimizer` values in `hardhat.config.js`
+- Change the total runs and toggle the optimizer by changing the `optimizer` values under `solidity.profiles.default.settings` in `hardhat.config.js`
 
 ### Foundry
 
@@ -51,7 +47,7 @@ Don't forget to give the project a star! Thanks again!
 
 #### Running a single test
 
-`forge test --match-path test\foundry\token\ERC721\ERC721FGasReporterMock.t.sol`
+`forge test --match-path test/foundry/token/ERC721/ERC721FGasReporterMock.t.sol`
 
 #### Testing gas consumption
 

--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ Please refer to [SECURITY.md](./SECURITY.md) for our security policy and how to 
 ### Installation
 
 ```
-npm install '@franknft.eth/erc721-f'
+npm install @franknft.eth/erc721-f
 ```
 
 ### Requirements
 
-- **Solidity**: `0.8.24` or higher
+- **Solidity**: `^0.8.20 <0.9.0` (the toolchain compiles with `0.8.24`)
 - **Node.js**: `>=24`
 - **OpenZeppelin**: `5.6.1`
 
@@ -74,8 +74,8 @@ pragma solidity ^0.8.20 <0.9.0;
 
 import "@franknft.eth/erc721-f/contracts/token/ERC721/ERC721FCOMMON.sol";
 
-contract Example is ERC721F {
-    constructor() ERC721F("Example", "Example", msg.sender) {
+contract Example is ERC721FCOMMON {
+    constructor() ERC721FCOMMON("Example", "Example", msg.sender) {
         setBaseTokenURI(
             "ipfs://QmVy7VQUFtTQawBsp4tbJPp9MgbTKS4L7WSDpZEdZUzsiD/"
         );
@@ -97,7 +97,7 @@ contract Example is ERC721F {
 }
 ```
 
-Or just import the file directly from Gitlab like this:
+Or just import the file directly from GitHub like this:
 
 ```solidity
 // SPDX-License-Identifier: MIT

--- a/docs/HARDHAT3_MIGRATION_NOTES.md
+++ b/docs/HARDHAT3_MIGRATION_NOTES.md
@@ -5,7 +5,7 @@ Baseline/rollback point: commit `1918d9f` (Hardhat 2, 314 passing + 1 pending, f
 
 ## Dependency set
 
-| Package                                                     | Before             | After                                                                                                                                         |
+| Package                                                     | Before             | After (as of 12-07-2026; later bumps tracked by dependabot)                                                                                   |
 | ----------------------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `hardhat`                                                   | ^2.12.4            | ^3.9.1                                                                                                                                        |
 | `@nomicfoundation/hardhat-toolbox`                          | ^2.0.0 (ethers v5) | replaced by `@nomicfoundation/hardhat-toolbox-mocha-ethers` ^3.0.7 (ethers v6, mocha 11, chai 6)                                              |

--- a/docs/HARDHAT3_MIGRATION_PLAN.md
+++ b/docs/HARDHAT3_MIGRATION_PLAN.md
@@ -1,5 +1,7 @@
 # Hardhat 3 Migration Plan (ERC721F)
 
+> **Status: COMPLETED (12-07-2026).** The migration shipped in commit `5a30b09` and issue #115 is closed. Statements below (e.g. "currently on a Hardhat 2 toolchain") describe the pre-migration state; this document is retained as the historical plan. See [HARDHAT3_MIGRATION_NOTES.md](./HARDHAT3_MIGRATION_NOTES.md) for what was actually done.
+
 ## Executive Summary
 
 This repository is currently on a Hardhat 2 toolchain and has validated compatibility with current test suites.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -30,12 +30,12 @@ examples/
 
 ## CONVENTIONS
 
--   Examples are pedagogical; they may prioritize clarity over production hardening.
--   Example imports may need local-path switching for local compile/test.
--   Treat `EIP-2535/` as separate workspace semantics, not root defaults.
+- Examples are pedagogical; they may prioritize clarity over production hardening.
+- Example imports may need local-path switching for local compile/test.
+- Treat `EIP-2535/` as separate workspace semantics, not root defaults.
 
 ## ANTI-PATTERNS
 
--   Assuming examples are production-hardened out of the box.
--   Running root hardhat flows against examples without adjusting import paths/source scope.
--   Mixing EIP-2535 artifact expectations with root artifact expectations.
+- Assuming examples are production-hardened out of the box.
+- Running root hardhat flows against examples without adjusting import paths/source scope.
+- Mixing EIP-2535 artifact expectations with root artifact expectations.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -26,16 +26,18 @@ examples/
 | Merkle whitelist          | `MerkleRoot.sol`                           | proof verification sale path     |
 | VRF-based randomization   | `ChainLink.sol`                            | external coordinator assumptions |
 | On-chain metadata         | `OnChain.sol`, `OnChainOptimized.sol`      | tokenURI generation strategies   |
+| Metadata refresh events   | `ERC4906.sol`                              | EIP-4906 metadata-update signals |
+| Cross-collection gating   | `ERC721FVerifyImplementation.sol`          | mint gated on FreeMint ownership |
 | Non-core proxy/delegation | `proxy/*.sol`                              | standalone integration patterns  |
 
 ## CONVENTIONS
 
 - Examples are pedagogical; they may prioritize clarity over production hardening.
-- Example imports may need local-path switching for local compile/test.
+- Example imports use the published package name; `npm run update-example-imports:dev` (root) rewrites them to local paths, `:prod` restores.
 - Treat `EIP-2535/` as separate workspace semantics, not root defaults.
 
 ## ANTI-PATTERNS
 
 - Assuming examples are production-hardened out of the box.
-- Running root hardhat flows against examples without adjusting import paths/source scope.
+- Running example compiles/tests without first running `npm run update-example-imports:dev`.
 - Mixing EIP-2535 artifact expectations with root artifact expectations.

--- a/examples/EIP-2535/AGENTS.md
+++ b/examples/EIP-2535/AGENTS.md
@@ -3,9 +3,11 @@
 Inherits from `../AGENTS.md`. This file lists EIP-2535 workspace specifics only.
 
 ## OVERVIEW
+
 Isolated Diamond Standard workspace with its own package/config, contracts, deploy scripts, and tests.
 
 ## STRUCTURE
+
 ```text
 examples/EIP-2535/
 ├── contracts/
@@ -25,20 +27,23 @@ examples/EIP-2535/
 ```
 
 ## WHERE TO LOOK
-| Task | Location | Notes |
-|------|----------|-------|
-| Diamond storage shape | `contracts/ERC721F/ERC721FStorage.sol` | storage compatibility anchor |
-| Upgradeable ERC721 behavior | `contracts/ERC721F/ERC721FUpgradeable*.sol` | workspace-specific variant |
-| Facet initialization/mint flow | `contracts/InitFacet.sol`, `contracts/MintFacet.sol` | facet split responsibilities |
-| Sale controls | `contracts/SaleControl.sol` | sale toggles/limits |
-| Deployment orchestration | `deploy/` | workspace hardhat-deploy scripts |
+
+| Task                           | Location                                             | Notes                            |
+| ------------------------------ | ---------------------------------------------------- | -------------------------------- |
+| Diamond storage shape          | `contracts/ERC721F/ERC721FStorage.sol`               | storage compatibility anchor     |
+| Upgradeable ERC721 behavior    | `contracts/ERC721F/ERC721FUpgradeable*.sol`          | workspace-specific variant       |
+| Facet initialization/mint flow | `contracts/InitFacet.sol`, `contracts/MintFacet.sol` | facet split responsibilities     |
+| Sale controls                  | `contracts/SaleControl.sol`                          | sale toggles/limits              |
+| Deployment orchestration       | `deploy/`                                            | workspace hardhat-deploy scripts |
 
 ## CONVENTIONS
+
 - Run this workspace independently (`npm run <script> --workspace=eip-2535` or from this directory).
 - Respect local `hardhat.config.js`; do not assume root hardhat settings/artifacts.
 - Keep diamond storage changes explicit and coordinated with facet logic.
 
 ## ANTI-PATTERNS
+
 - Referencing root artifacts/tests from inside this workspace.
 - Treating this workspace as interchangeable with root ERC721F contracts.
 - Editing facet/storage layout casually without migration/compatibility reasoning.

--- a/examples/EIP-2535/AGENTS.md
+++ b/examples/EIP-2535/AGENTS.md
@@ -20,7 +20,8 @@ examples/EIP-2535/
 │   ├── MintFacet.sol
 │   ├── SaleControl.sol
 │   └── WithStorage.sol
-├── deploy/
+├── deploy/           # deploy scripts (rocketh deployScript entry points)
+├── rocketh/          # rocketh config/deploy/environment — config layer for deploy/
 ├── test/
 ├── hardhat.config.js
 └── package.json
@@ -28,13 +29,13 @@ examples/EIP-2535/
 
 ## WHERE TO LOOK
 
-| Task                           | Location                                             | Notes                            |
-| ------------------------------ | ---------------------------------------------------- | -------------------------------- |
-| Diamond storage shape          | `contracts/ERC721F/ERC721FStorage.sol`               | storage compatibility anchor     |
-| Upgradeable ERC721 behavior    | `contracts/ERC721F/ERC721FUpgradeable*.sol`          | workspace-specific variant       |
-| Facet initialization/mint flow | `contracts/InitFacet.sol`, `contracts/MintFacet.sol` | facet split responsibilities     |
-| Sale controls                  | `contracts/SaleControl.sol`                          | sale toggles/limits              |
-| Deployment orchestration       | `deploy/`                                            | workspace hardhat-deploy scripts |
+| Task                           | Location                                             | Notes                                                                                                |
+| ------------------------------ | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Diamond storage shape          | `contracts/ERC721F/ERC721FStorage.sol`               | storage compatibility anchor                                                                         |
+| Upgradeable ERC721 behavior    | `contracts/ERC721F/ERC721FUpgradeable*.sol`          | workspace-specific variant                                                                           |
+| Facet initialization/mint flow | `contracts/InitFacet.sol`, `contracts/MintFacet.sol` | facet split responsibilities                                                                         |
+| Sale controls                  | `contracts/SaleControl.sol`                          | sale toggles/limits                                                                                  |
+| Deployment orchestration       | `deploy/` + `rocketh/`                               | rocketh-based (`deployScript` from `rocketh/deploy.js`); hardhat-deploy v2 is only the loaded plugin |
 
 ## CONVENTIONS
 
@@ -47,3 +48,4 @@ examples/EIP-2535/
 - Referencing root artifacts/tests from inside this workspace.
 - Treating this workspace as interchangeable with root ERC721F contracts.
 - Editing facet/storage layout casually without migration/compatibility reasoning.
+- Weakening burn authorization in `ERC721FUpgradeable`: burn must stay gated by `_isApprovedOrOwner` (an any-caller-can-burn bug was fixed in c9f1f34).

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -13,6 +13,7 @@ test/
 ├── hardhat/
 │   ├── behaviours/
 │   ├── examples/
+│   ├── helpers/
 │   ├── tooling/
 │   ├── utils/
 │   └── token/
@@ -21,6 +22,8 @@ test/
 │       └── soulbound/
 └── foundry/
     ├── examples/
+    │   ├── gas-optimisations/
+    │   └── mocks/
     ├── utils/
     └── token/
         ├── ERC721/
@@ -38,6 +41,8 @@ test/
 | Utility contract coverage       | `hardhat/utils/`, `foundry/utils/`                     | allowlists, payable, address utils    |
 | Gas/break-even solidity tests   | `foundry/token/ERC721/*.t.sol`                         | forge-native metrics                  |
 | Example-contract foundry checks | `foundry/examples/`                                    | example integration validation        |
+| Example-contract hardhat checks | `hardhat/examples/`                                    | incl. EIP-2535 workspace delegator    |
+| Tooling guard tests             | `hardhat/tooling/`                                     | husky/prettier configuration checks   |
 
 ## CONVENTIONS
 


### PR DESCRIPTION
## Why

A full audit of the repo's 14 first-party markdown files (08-08-2026) cross-checked every command, path, and version claim against the current Hardhat 3 stack. Four files were clean; these are the fixes for the rest.

## What

- **CONTRIBUTING.md** — the two "Warning" blocks described manual example-import rewriting and `paths.sources` switching; both are automated since the HH3 migration (`npm run update-example-imports:dev|prod`, multi-path compile). Also: optimizer now under `solidity.profiles.default.settings`, and the single-test command used Windows backslashes.
- **README.md** — Solidity requirement corrected to `^0.8.20 <0.9.0` (toolchain compiles 0.8.24; "0.8.24 or higher" was wrong at both ends); usage example now inherits `ERC721FCOMMON` matching its import; "Gitlab"→GitHub; unquoted the npm install.
- **BENCHMARK.md** — node ≥24; optimizer snippet in HH3 profile shape; the "side by side" block no longer contradicts its own note; added a caveat that figures date from 18-05-2026 (Foundry toolchain unchanged, Hardhat cross-validation pre-dates HH3).
- **docs/HARDHAT3_MIGRATION_PLAN.md** — status banner: completed 12-07-2026 in `5a30b09`, issue #115 closed; content retained as history.
- **docs/HARDHAT3_MIGRATION_NOTES.md** — "After" column date-scoped so later dependabot bumps don't falsify it.
- **AGENTS.md ×4** — header stamp was fiction (unrelated commit `f394aab`); EIP-2535 deploy layer is rocketh-based, not "hardhat-deploy scripts" (added `rocketh/` to the tree); documented the burn-authorization invariant from `c9f1f34` as an anti-pattern; noted the root suite delegates into the EIP-2535 workspace; added missing lookup rows (ERC4906, ERC721FVerifyImplementation, `hardhat/examples/`, `hardhat/tooling/`) and tree entries (`helpers/`, foundry example subdirs); added lint/CI commands.

Two commits: a prettier-only style pass on the two non-conforming AGENTS files, then the content fixes. Net content diff: 9 files, +60/−40 lines.

## Verification

- `prettier --check` passes on all touched files.
- Every claim added was verified against source (constructor signatures, config shapes, script definitions, workflow triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)