### PR TITLE
build(deps): upgrade prettier-plugin-solidity to 2.4.1

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,7 +7,7 @@
         {
             "files": "*.sol",
             "options": {
-                "parser": "solidity-parse",
+                "parser": "slang",
                 "printWidth": 80,
                 "tabWidth": 4,
                 "useTabs": false,

--- a/contracts/mocks/ERC721FCOMMONMock.sol
+++ b/contracts/mocks/ERC721FCOMMONMock.sol
@@ -15,7 +15,7 @@ contract ERC721FCOMMONMock is ERC721FCOMMON {
 
     function mint(uint256 numberOfTokens) public {
         uint256 supply = _totalMinted();
-        for (uint256 i; i < numberOfTokens; ) {
+        for (uint256 i; i < numberOfTokens;) {
             _mint(msg.sender, supply + i);
             unchecked {
                 i++;

--- a/contracts/mocks/ERC721FEnumerableMock.sol
+++ b/contracts/mocks/ERC721FEnumerableMock.sol
@@ -19,7 +19,7 @@ contract ERC721FEnumerableMock is ERC721FEnumerable {
      */
     function mint(uint256 numberOfTokens) public {
         uint256 supply = _totalMinted();
-        for (uint256 i; i < numberOfTokens; ) {
+        for (uint256 i; i < numberOfTokens;) {
             _mint(msg.sender, supply + i);
             unchecked {
                 i++;

--- a/contracts/mocks/ERC721FEnumerableStartAtOneMock.sol
+++ b/contracts/mocks/ERC721FEnumerableStartAtOneMock.sol
@@ -16,7 +16,7 @@ contract ERC721FEnumerableStartAtOneMock is ERC721FEnumerable {
     function mint(uint256 numberOfTokens) public {
         uint256 supply = _totalMinted();
         uint256 startTokenId = _startTokenId();
-        for (uint256 i; i < numberOfTokens; ) {
+        for (uint256 i; i < numberOfTokens;) {
             _mint(msg.sender, startTokenId + supply + i);
             unchecked {
                 i++;

--- a/contracts/mocks/ERC721FGasReporterMock.sol
+++ b/contracts/mocks/ERC721FGasReporterMock.sol
@@ -55,7 +55,7 @@ contract ERC721FGasReporterMock is ERC721F {
      */
     function transferTenAsc(address to) public {
         unchecked {
-            for (uint256 i = 0; i < 10; ) {
+            for (uint256 i = 0; i < 10;) {
                 transferFrom(msg.sender, to, retrieveFirstToken());
                 i++;
             }
@@ -67,7 +67,7 @@ contract ERC721FGasReporterMock is ERC721F {
      */
     function transferTenDesc(address to) public {
         unchecked {
-            for (uint256 i = 0; i < 10; ) {
+            for (uint256 i = 0; i < 10;) {
                 transferFrom(msg.sender, to, retrieveLastToken());
                 i++;
             }
@@ -79,7 +79,7 @@ contract ERC721FGasReporterMock is ERC721F {
      */
     function transferFiftyAsc(address to) public {
         unchecked {
-            for (uint256 i = 0; i < 50; ) {
+            for (uint256 i = 0; i < 50;) {
                 transferFrom(msg.sender, to, retrieveFirstToken());
                 i++;
             }
@@ -91,7 +91,7 @@ contract ERC721FGasReporterMock is ERC721F {
      */
     function transferFiftyDesc(address to) public {
         unchecked {
-            for (uint256 i = 0; i < 50; ) {
+            for (uint256 i = 0; i < 50;) {
                 transferFrom(msg.sender, to, retrieveLastToken());
                 i++;
             }
@@ -100,7 +100,7 @@ contract ERC721FGasReporterMock is ERC721F {
 
     function transferAsc(uint256 total, address to) public {
         unchecked {
-            for (uint256 i = 0; i < total; ) {
+            for (uint256 i = 0; i < total;) {
                 transferFrom(msg.sender, to, retrieveFirstToken());
                 i++;
             }
@@ -109,7 +109,7 @@ contract ERC721FGasReporterMock is ERC721F {
 
     function transferDesc(uint256 total, address to) public {
         unchecked {
-            for (uint256 i = 0; i < total; ) {
+            for (uint256 i = 0; i < total;) {
                 transferFrom(msg.sender, to, retrieveLastToken());
                 i++;
             }
@@ -122,7 +122,7 @@ contract ERC721FGasReporterMock is ERC721F {
     function mint(address to, uint256 numberOfTokens) internal {
         uint256 supply = _totalMinted();
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _mint(to, supply + i);
                 i++;
             }
@@ -139,7 +139,7 @@ contract ERC721FGasReporterMock is ERC721F {
     {
         uint256 totalSupply = _totalMinted();
         unchecked {
-            for (uint256 i = 0; i < totalSupply; ) {
+            for (uint256 i = 0; i < totalSupply;) {
                 if (ownerOf(i) == msg.sender) {
                     return i;
                 }
@@ -158,7 +158,7 @@ contract ERC721FGasReporterMock is ERC721F {
     {
         uint256 totalSupply = _totalMinted();
         unchecked {
-            for (uint256 i = totalSupply - 1; i >= 0; ) {
+            for (uint256 i = totalSupply - 1; i >= 0;) {
                 if (ownerOf(i) == msg.sender) {
                     return i;
                 }

--- a/contracts/mocks/ERC721FMock.sol
+++ b/contracts/mocks/ERC721FMock.sol
@@ -20,7 +20,7 @@ contract ERC721FMock is ERC721F {
      */
     function mint(uint256 numberOfTokens) public {
         uint256 supply = _totalMinted();
-        for (uint256 i; i < numberOfTokens; ) {
+        for (uint256 i; i < numberOfTokens;) {
             _mint(msg.sender, supply + i);
             unchecked {
                 i++;

--- a/contracts/mocks/ERC721FWalletOfOwnerStorageMock.sol
+++ b/contracts/mocks/ERC721FWalletOfOwnerStorageMock.sol
@@ -19,7 +19,7 @@ contract ERC721FWalletOfOwnerStorageMock is ERC721FWalletOfOwnerStorage {
      */
     function mint(uint256 numberOfTokens) public {
         uint256 supply = totalSupply();
-        for (uint256 i; i < numberOfTokens; ) {
+        for (uint256 i; i < numberOfTokens;) {
             _mint(msg.sender, supply + i);
             unchecked {
                 i++;

--- a/contracts/mocks/OZErc721EnumerableGasReporterMock.sol
+++ b/contracts/mocks/OZErc721EnumerableGasReporterMock.sol
@@ -53,7 +53,7 @@ contract OZErc721EnumerableGasReporterMock is ERC721Enumerable {
     /// @notice Transfers the first token ten times
     function transferTenAsc(address to) public {
         unchecked {
-            for (uint256 i = 0; i < 10; ) {
+            for (uint256 i = 0; i < 10;) {
                 transferFrom(
                     msg.sender,
                     to,
@@ -67,7 +67,7 @@ contract OZErc721EnumerableGasReporterMock is ERC721Enumerable {
     /// @notice Transfers the last token ten times
     function transferTenDesc(address to) public {
         unchecked {
-            for (uint256 i = 0; i < 10; ) {
+            for (uint256 i = 0; i < 10;) {
                 uint256 last = balanceOf(msg.sender) - 1;
                 transferFrom(
                     msg.sender,
@@ -82,7 +82,7 @@ contract OZErc721EnumerableGasReporterMock is ERC721Enumerable {
     /// @notice Transfers the first token fifty times
     function transferFiftyAsc(address to) public {
         unchecked {
-            for (uint256 i = 0; i < 50; ) {
+            for (uint256 i = 0; i < 50;) {
                 transferFrom(
                     msg.sender,
                     to,
@@ -96,7 +96,7 @@ contract OZErc721EnumerableGasReporterMock is ERC721Enumerable {
     /// @notice Transfers the last token fifty times
     function transferFiftyDesc(address to) public {
         unchecked {
-            for (uint256 i = 0; i < 50; ) {
+            for (uint256 i = 0; i < 50;) {
                 uint256 last = balanceOf(msg.sender) - 1;
                 transferFrom(
                     msg.sender,
@@ -115,7 +115,7 @@ contract OZErc721EnumerableGasReporterMock is ERC721Enumerable {
     function _mintBatch(address to, uint256 count) internal {
         uint256 startId = _nextTokenId;
         unchecked {
-            for (uint256 i = 0; i < count; ) {
+            for (uint256 i = 0; i < count;) {
                 _mint(to, startId + i);
                 i++;
             }

--- a/contracts/token/ERC721/extensions/ERC721FWalletOfOwnerStorage.sol
+++ b/contracts/token/ERC721/extensions/ERC721FWalletOfOwnerStorage.sol
@@ -59,7 +59,7 @@ abstract contract ERC721FWalletOfOwnerStorage is ERC721F {
         // instead of on every element access.
         uint256[] storage wallet = _walletOfOwner[owner];
         uint256 length = wallet.length;
-        for (uint256 i; i < length; ) {
+        for (uint256 i; i < length;) {
             if (wallet[i] == tokenId) {
                 wallet[i] = wallet[length - 1];
                 wallet.pop();

--- a/contracts/utils/AddressUtils.sol
+++ b/contracts/utils/AddressUtils.sol
@@ -145,10 +145,9 @@ library AddressUtils {
         bytes memory ss = bytes(s);
         if (ss.length % 2 != 0) revert HexStringHasOddLength();
         bytes memory r = new bytes(ss.length / 2);
-        for (uint256 i = 0; i < ss.length / 2; ) {
+        for (uint256 i = 0; i < ss.length / 2;) {
             r[i] = bytes1(
-                fromHexChar(uint8(ss[2 * i])) *
-                    16 +
+                fromHexChar(uint8(ss[2 * i])) * 16 +
                     fromHexChar(uint8(ss[2 * i + 1]))
             );
             unchecked {

--- a/contracts/utils/AllowList.sol
+++ b/contracts/utils/AllowList.sol
@@ -37,7 +37,7 @@ abstract contract AllowList is Ownable {
      */
     function allowAddresses(address[] calldata _addresses) external onlyOwner {
         uint256 length = _addresses.length;
-        for (uint256 i; i < length; ) {
+        for (uint256 i; i < length;) {
             // The internal variant skips the redundant onlyOwner check that
             // the public allowAddress would re-run on every iteration.
             _allowAddress(_addresses[i]);

--- a/contracts/utils/AllowListWithAmount.sol
+++ b/contracts/utils/AllowListWithAmount.sol
@@ -14,8 +14,9 @@ abstract contract AllowListWithAmount is Ownable {
 
     error InsufficientAllowListTokens();
 
-    modifier onlyAllowListWithSufficientAvailableTokens(uint256 numberOfTokens)
-    {
+    modifier onlyAllowListWithSufficientAvailableTokens(
+        uint256 numberOfTokens
+    ) {
         if (numberOfTokens > allowList[msg.sender]) {
             revert InsufficientAllowListTokens();
         }
@@ -30,7 +31,7 @@ abstract contract AllowListWithAmount is Ownable {
         uint256 totalTokens
     ) external onlyOwner {
         uint256 length = _addresses.length;
-        for (uint256 i; i < length; ) {
+        for (uint256 i; i < length;) {
             // The internal variant skips the redundant onlyOwner check that
             // the public allowAddress would re-run on every iteration.
             _allowAddress(_addresses[i], totalTokens);

--- a/contracts/utils/Verify.sol
+++ b/contracts/utils/Verify.sol
@@ -41,10 +41,10 @@ contract Verify {
         return
             msg.sender == tokenOwner ||
             msg.sender ==
-            WarmInterface(WARM_WALLET_CONTRACT).ownerOf(
-                tokenContract,
-                tokenId
-            ) ||
+                WarmInterface(WARM_WALLET_CONTRACT).ownerOf(
+                    tokenContract,
+                    tokenId
+                ) ||
             DelegateCashInterface(DELEGATE_CASH_CONTRACT).checkDelegateForToken(
                 msg.sender,
                 tokenOwner,

--- a/examples/AllowList.sol
+++ b/examples/AllowList.sol
@@ -70,7 +70,7 @@ contract AllowListExample is ERC721FCOMMON, AllowList {
         );
 
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _mint(msg.sender, supply + i);
                 i++;
             }
@@ -93,7 +93,7 @@ contract AllowListExample is ERC721FCOMMON, AllowList {
         );
 
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _safeMint(msg.sender, supply + i);
                 i++;
             }

--- a/examples/AllowListWithAmount.sol
+++ b/examples/AllowListWithAmount.sol
@@ -70,7 +70,7 @@ contract AllowListWithAmountExample is ERC721FCOMMON, AllowListWithAmount {
         );
 
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _mint(msg.sender, supply + i);
                 i++;
             }
@@ -99,7 +99,7 @@ contract AllowListWithAmountExample is ERC721FCOMMON, AllowListWithAmount {
 
         decreaseAddressAvailableTokens(msg.sender, numberOfTokens);
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _safeMint(msg.sender, supply + i);
                 i++;
             }

--- a/examples/ChainLink.sol
+++ b/examples/ChainLink.sol
@@ -108,7 +108,7 @@ contract ChainLink is ERC721F, VRFConsumerBaseV2 {
         );
 
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _mint(msg.sender, (startingIndex + supply + i) % MAX_TOKENS); // no need to use safeMint as we don't allow contracts.
                 i++;
             }

--- a/examples/EIP-2535/contracts/ERC721F/ERC721FStorage.sol
+++ b/examples/EIP-2535/contracts/ERC721F/ERC721FStorage.sol
@@ -31,8 +31,9 @@ library ERC721FStorage {
         string _baseTokenURI;
     }
 
-    bytes32 internal constant STORAGE_SLOT =
-        keccak256("ERC721F.contracts.storage.ERC721F");
+    bytes32 internal constant STORAGE_SLOT = keccak256(
+        "ERC721F.contracts.storage.ERC721F"
+    );
 
     function layout() internal pure returns (Layout storage l) {
         bytes32 slot = STORAGE_SLOT;

--- a/examples/EIP-2535/contracts/ERC721F/ERC721FUpgradeable.sol
+++ b/examples/EIP-2535/contracts/ERC721F/ERC721FUpgradeable.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20 <0.9.0;
 
-import {ERC721FUpgradeableInternal, ERC721FStorage} from "./ERC721FUpgradeableInternal.sol";
+import {
+    ERC721FUpgradeableInternal,
+    ERC721FStorage
+} from "./ERC721FUpgradeableInternal.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import {UsingDiamondOwner} from "@rocketh/diamond/solc_0_8/UsingDiamondOwner.sol";
 

--- a/examples/EIP-2535/contracts/InitFacet.sol
+++ b/examples/EIP-2535/contracts/InitFacet.sol
@@ -4,8 +4,14 @@ pragma solidity ^0.8.20 <0.9.0;
 import {IDiamondLoupe} from "@rocketh/diamond/solc_0_8/interfaces/IDiamondLoupe.sol";
 import {IERC173} from "@rocketh/diamond/solc_0_8/interfaces/IERC173.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
-import {IERC721, IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import {UsingDiamondOwner, IDiamondCut} from "@rocketh/diamond/solc_0_8/UsingDiamondOwner.sol";
+import {
+    IERC721,
+    IERC721Metadata
+} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {
+    UsingDiamondOwner,
+    IDiamondCut
+} from "@rocketh/diamond/solc_0_8/UsingDiamondOwner.sol";
 import {ERC721FStorage} from "./ERC721F/ERC721FStorage.sol";
 import {WithStorage} from "./WithStorage.sol";
 
@@ -18,8 +24,8 @@ contract InitFacet is UsingDiamondOwner, WithStorage {
 
         f()._name = "FreeMint";
         f()._symbol = "FM";
-        f()
-            ._baseTokenURI = "ipfs://QmVy7VQUFtTQawBsp4tbJPp9MgbTKS4L7WSDpZEdZUzsiD/";
+        f()._baseTokenURI =
+            "ipfs://QmVy7VQUFtTQawBsp4tbJPp9MgbTKS4L7WSDpZEdZUzsiD/";
 
         s().MAX_TOKENS = 10000;
         s().MAX_PURCHASE = 31;

--- a/examples/EIP-2535/contracts/MintFacet.sol
+++ b/examples/EIP-2535/contracts/MintFacet.sol
@@ -26,7 +26,7 @@ contract MintFacet is ERC721FUpgradeableInternal, WithStorage {
             "Purchase would exceed max supply of Tokens"
         );
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _mint(msg.sender, supply + i); // no need to use safeMint as we don't allow contracts.
                 i++;
             }

--- a/examples/ERC4906.sol
+++ b/examples/ERC4906.sol
@@ -39,7 +39,7 @@ contract ERC4906 is ERC721F, ERC721URIStorage {
             "Purchase would exceed max supply of Tokens"
         );
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 uint256 nextTokenId = supply + i;
                 _mint(msg.sender, nextTokenId); // no need to use safeMint as we don't allow contracts.
                 super._setTokenURI(nextTokenId, _tokenURI);
@@ -99,7 +99,7 @@ contract ERC4906 is ERC721F, ERC721URIStorage {
         string memory _tokenURI
     ) internal virtual {
         unchecked {
-            for (uint256 i = _fromTokenId; i <= _toTokenId; ) {
+            for (uint256 i = _fromTokenId; i <= _toTokenId;) {
                 if (_exists(i)) {
                     require(
                         ownerOf(i) == msg.sender,

--- a/examples/FreeMint.sol
+++ b/examples/FreeMint.sol
@@ -65,7 +65,7 @@ contract FreeMint is ERC721F, ERC2981 {
             "Purchase would exceed max supply of Tokens"
         );
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _mint(msg.sender, supply + i); // no need to use safeMint as we don't allow contracts.
                 i++;
             }

--- a/examples/MerkleRoot.sol
+++ b/examples/MerkleRoot.sol
@@ -87,7 +87,7 @@ contract MerkleRoot is ERC721F, Payable {
         );
 
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _mint(msg.sender, supply + i); // no need to use safeMint as we don't allow contracts.
                 i++;
             }
@@ -115,7 +115,7 @@ contract MerkleRoot is ERC721F, Payable {
         _preSaleMinted[msg.sender] = true;
 
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _safeMint(msg.sender, supply + i);
                 i++;
             }

--- a/examples/OnChain.sol
+++ b/examples/OnChain.sol
@@ -60,7 +60,7 @@ contract OnChain is ERC721FOnChain {
         );
 
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _mint(msg.sender, supply + i); // no need to use safeMint as we don't allow contracts.
                 i++;
             }
@@ -92,14 +92,14 @@ contract OnChain is ERC721FOnChain {
         parts[0] = SVG_HEAD;
         parts[1] = name();
         parts[2] = '</tspan><tspan font-size="65" x="50%" dy="20%">';
-        parts[3] = id % 100 == 0 && id != 0
-            ? pokemon[9]
-            : pokemon[id % (pokemon.length - 1)];
+        parts[3] =
+            id % 100 == 0 && id != 0
+                ? pokemon[9]
+                : pokemon[id % (pokemon.length - 1)];
         parts[4] = '</tspan><tspan font-size="20" x="50%" dy="15%">';
         parts[5] = getDescription();
-        parts[
-            6
-        ] = '</tspan></text><path fill="transparent" stroke="gold" stroke-width="2" d="M338.971 322.5 300 345l-38.971-22.5v-45L300 255l38.971 22.5z"/><text font-size="15" fill="#fff" font-weight="bold" font-family="Cursive" x="300" y="300" class="centered-text">';
+        parts[6] =
+            '</tspan></text><path fill="transparent" stroke="gold" stroke-width="2" d="M338.971 322.5 300 345l-38.971-22.5v-45L300 255l38.971 22.5z"/><text font-size="15" fill="#fff" font-weight="bold" font-family="Cursive" x="300" y="300" class="centered-text">';
         parts[7] = Strings.toString(id);
         parts[8] = SVG_FOOTER;
 

--- a/examples/OnChainOptimized.sol
+++ b/examples/OnChainOptimized.sol
@@ -87,8 +87,8 @@ contract OnChainOptimized is IERC4883, ERC721F {
         unchecked {
             while (numberOfTokens != 0) {
                 uint256 tokenId = supply + 1;
-                uint256 algorithmId = lastSelected +
-                    createRandomNumber(tokenId);
+                uint256 algorithmId =
+                    lastSelected + createRandomNumber(tokenId);
                 _mint(msg.sender, tokenId);
                 idToAlgorithmId[tokenId] = algorithmId;
                 lastSelected = algorithmId;
@@ -148,16 +148,17 @@ contract OnChainOptimized is IERC4883, ERC721F {
      */
     function createRandomNumber(uint256 tokenId) public view returns (uint256) {
         unchecked {
-            uint256 random = uint256(
-                keccak256(
-                    abi.encodePacked(
-                        block.timestamp,
-                        block.prevrandao,
-                        tokenId,
-                        msg.sender
+            uint256 random =
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            block.timestamp,
+                            block.prevrandao,
+                            tokenId,
+                            msg.sender
+                        )
                     )
-                )
-            ) % 32;
+                ) % 32;
             return random;
         }
     }
@@ -341,8 +342,8 @@ contract OnChainOptimized is IERC4883, ERC721F {
             '<circle cy="580" cx="330" r="60" stroke="none"/><circle cy="580" cx="330" r="40" fill="#fff" stroke="none"/>',
             '<rect y="530" x="280" width="100" height="120" stroke-width="8"/><rect y="530" x="290" width="80" height="100" stroke-width="8" fill="#fff"/>'
         ];
-        string
-            memory lowerPartPurse = '<rect y="580" x="240" width="180" height="120" stroke-width="8" ';
+        string memory lowerPartPurse =
+            '<rect y="580" x="240" width="180" height="120" stroke-width="8" ';
         string[4] memory designPurse = [
             'fill="#f73149"/><rect y="600" x="260" width="140" height="80" stroke-width="8" fill="#f58822"/><rect y="620" x="280" width="100" height="40" stroke-width="8" fill="#f5c43d"/>',
             'fill="#9F87FB"/><rect y="650" x="310" width="30" height="30" stroke-width="8" fill="#e06cf5"/><rect y="590" x="350" width="30" height="30" stroke-width="8" fill="#e06cf5"/><rect y="640" x="380" width="30" height="30" stroke-width="8" fill="#e06cf5"/><rect y="610" x="260" width="30" height="30" stroke-width="8" fill="#e06cf5"/>',

--- a/examples/mocks/FreeMintMock.sol
+++ b/examples/mocks/FreeMintMock.sol
@@ -28,7 +28,7 @@ contract FreeMintMock is FreeMint {
             "Purchase would exceed max supply of Tokens"
         );
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _mint(msg.sender, supply + i); // no need to use safeMint as we don't allow contracts.
                 i++;
             }
@@ -54,7 +54,7 @@ contract FreeMintMock is FreeMint {
             "Purchase would exceed max supply of Tokens"
         );
         unchecked {
-            for (uint256 i; i < numberOfTokens; ) {
+            for (uint256 i; i < numberOfTokens;) {
                 _mint(msg.sender, supply + i); // no need to use safeMint as we don't allow contracts.
                 i++;
             }

--- a/examples/proxy/DelegationRegistry.sol
+++ b/examples/proxy/DelegationRegistry.sol
@@ -286,7 +286,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         info = new IDelegationRegistry.DelegationInfo[](
             potentialDelegationHashesLength
         );
-        for (uint256 i = 0; i < potentialDelegationHashesLength; ) {
+        for (uint256 i = 0; i < potentialDelegationHashesLength;) {
             bytes32 delegateHash = potentialDelegationHashes.at(i);
             IDelegationRegistry.DelegationInfo
                 memory delegationInfo_ = delegationInfo[delegateHash];
@@ -401,7 +401,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         uint256 potentialDelegatesLength = delegationHashes_.length();
         uint256 delegatesCount = 0;
         delegates = new address[](potentialDelegatesLength);
-        for (uint256 i = 0; i < potentialDelegatesLength; ) {
+        for (uint256 i = 0; i < potentialDelegatesLength;) {
             bytes32 delegationHash = delegationHashes_.at(i);
             DelegationInfo storage delegationInfo_ = delegationInfo[
                 delegationHash
@@ -491,7 +491,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         contractDelegations = new IDelegationRegistry.ContractDelegation[](
             potentialLength
         );
-        for (uint256 i = 0; i < potentialLength; ) {
+        for (uint256 i = 0; i < potentialLength;) {
             bytes32 delegationHash = delegationHashes_.at(i);
             DelegationInfo storage delegationInfo_ = delegationInfo[
                 delegationHash
@@ -549,7 +549,7 @@ contract DelegationRegistry is IDelegationRegistry, ERC165 {
         tokenDelegations = new IDelegationRegistry.TokenDelegation[](
             potentialLength
         );
-        for (uint256 i = 0; i < potentialLength; ) {
+        for (uint256 i = 0; i < potentialLength;) {
             bytes32 delegationHash = delegationHashes_.at(i);
             DelegationInfo storage delegationInfo_ = delegationInfo[
                 delegationHash

--- a/examples/proxy/HotWalletProxy.sol
+++ b/examples/proxy/HotWalletProxy.sol
@@ -123,7 +123,7 @@ contract HotWalletProxy is
 
         bool needsResize = false;
         uint256 index = 0;
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i = 0; i < length;) {
             WalletLink memory walletLink = walletLinks[i];
             if (walletLink.expirationTimestamp >= timestamp) {
                 addresses[index] = walletLink.walletAddress;
@@ -146,7 +146,7 @@ contract HotWalletProxy is
         if (needsResize) {
             address[] memory resizedAddresses = new address[](index);
 
-            for (uint256 i = 0; i < index; ) {
+            for (uint256 i = 0; i < index;) {
                 resizedAddresses[i] = addresses[i];
 
                 unchecked {
@@ -171,7 +171,7 @@ contract HotWalletProxy is
         uint256 timestamp = block.timestamp;
 
         if (length > 0) {
-            for (uint256 i = length; i > 0; ) {
+            for (uint256 i = length; i > 0;) {
                 uint256 index = i - 1;
                 if (coldWalletLinks[index].expirationTimestamp < timestamp) {
                     /**
@@ -182,9 +182,8 @@ contract HotWalletProxy is
                         hotWalletToColdWallets[hotWalletAddress].pop();
                     } else {
                         WalletLink memory toSwap = coldWalletLinks[length - 1];
-                        hotWalletToColdWallets[hotWalletAddress][
-                            index
-                        ] = toSwap;
+                        hotWalletToColdWallets[hotWalletAddress][index] =
+                            toSwap;
 
                         hotWalletToColdWallets[hotWalletAddress].pop();
                     }
@@ -213,7 +212,7 @@ contract HotWalletProxy is
         );
 
         uint256 length = coldWallets.length;
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i = 0; i < length;) {
             if (coldWallets[i] == coldWalletAddress) {
                 return i;
             }
@@ -356,7 +355,7 @@ contract HotWalletProxy is
         );
 
         uint256 length = coldWallets.length;
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i = 0; i < length;) {
             address coldWallet = coldWallets[i];
 
             _setColdWalletToHotWallet(coldWallet, address(0), 0);
@@ -409,15 +408,15 @@ contract HotWalletProxy is
             .walletAddress;
 
         if (hotWalletAddress != address(0)) {
-            coldWalletToHotWallet[coldWalletAddress]
-                .expirationTimestamp = expirationTimestamp;
+            coldWalletToHotWallet[coldWalletAddress].expirationTimestamp =
+                expirationTimestamp;
 
             WalletLink[] memory coldWalletLinks = hotWalletToColdWallets[
                 hotWalletAddress
             ];
             uint256 length = coldWalletLinks.length;
 
-            for (uint256 i = 0; i < length; ) {
+            for (uint256 i = 0; i < length;) {
                 if (coldWalletLinks[i].walletAddress == coldWalletAddress) {
                     hotWalletToColdWallets[hotWalletAddress][i]
                         .expirationTimestamp = expirationTimestamp;
@@ -443,7 +442,7 @@ contract HotWalletProxy is
 
         uint256 total = 0;
         uint256 length = coldWallets.length;
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i = 0; i < length;) {
             address coldWallet = coldWallets[i];
 
             total += erc721Contract.balanceOf(coldWallet);
@@ -489,7 +488,7 @@ contract HotWalletProxy is
 
         uint256[] memory totals = new uint256[](ownersLength);
 
-        for (uint256 i = 0; i < ownersLength; ) {
+        for (uint256 i = 0; i < ownersLength;) {
             address owner = owners[i];
             uint256 id = ids[i];
 
@@ -515,7 +514,7 @@ contract HotWalletProxy is
             allWallets[allWalletsLength] = owner;
             batchIds[allWalletsLength] = id;
 
-            for (uint256 j = 0; j < coldWalletsLength; ) {
+            for (uint256 j = 0; j < coldWalletsLength;) {
                 address coldWallet = coldWallets[j];
 
                 allWallets[j] = coldWallet;
@@ -533,7 +532,7 @@ contract HotWalletProxy is
 
             uint256 total = 0;
             uint256 balancesLength = balances.length;
-            for (uint256 j = 0; j < balancesLength; ) {
+            for (uint256 j = 0; j < balancesLength;) {
                 total += balances[j];
 
                 unchecked {
@@ -562,7 +561,7 @@ contract HotWalletProxy is
 
         uint256 total = 0;
         uint256 length = coldWallets.length;
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i = 0; i < length;) {
             address coldWallet = coldWallets[i];
 
             total += erc1155Contract.balanceOf(coldWallet, tokenId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "mocha": "^11.7.6",
                 "operator-filter-registry": "^1.3.1",
                 "prettier": "^3.8.1",
-                "prettier-plugin-solidity": "^1.1.3",
+                "prettier-plugin-solidity": "^2.4.1",
                 "solhint": "^6.1.0",
                 "solhint-plugin-prettier": "^0.1.0"
             },
@@ -154,6 +154,13 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@bytecodealliance/preview2-shim": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.19.0.tgz",
+            "integrity": "sha512-OSUlcM62fXLuzYP0DjBn/SwjKMZ/y/2PMXZ8v5cRiiFcroauntlPRl/oCnx0xYjYiqdYvE0PY50VCNutll0xOw==",
+            "dev": true,
+            "license": "(Apache-2.0 WITH LLVM-exception)"
         },
         "node_modules/@chainlink/contracts": {
             "version": "1.5.0",
@@ -2485,6 +2492,16 @@
             "integrity": "sha512-OoS5eQi9WBeiYI6EXurhqrpr6syRVhnaUzdx5fyK/1syKGq9BsjWWHXTNru0qk5ZFQ9f/KMTZotcDZD4eAdCpg==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/@nomicfoundation/slang": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/slang/-/slang-1.3.8.tgz",
+            "integrity": "sha512-it0o2vGb56kqOEUiIreLTqEwiWitWDDOiUCWCO3PfzBXD3kkIFLQ3Ly/4xNgCo0LF5xqGECr+DcCNbfspSClPA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bytecodealliance/preview2-shim": "^0.19.0"
+            }
         },
         "node_modules/@nomicfoundation/solidity-analyzer": {
             "version": "0.1.2",
@@ -6934,20 +6951,21 @@
             }
         },
         "node_modules/prettier-plugin-solidity": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.4.3.tgz",
-            "integrity": "sha512-Mrr/iiR9f9IaeGRMZY2ApumXcn/C5Gs3S7B7hWB3gigBFML06C0yEyW86oLp0eqiA0qg+46FaChgLPJCj/pIlg==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-2.4.1.tgz",
+            "integrity": "sha512-12w85zZt9gXgGvLW7nK4h+U6sLY8qa688E+tFDP0Oic9zuM5TSQcWQdcE/RP3dLBuBAbA5yUl6lgXmSnjuRsGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@solidity-parser/parser": "^0.20.1",
-                "semver": "^7.7.1"
+                "@nomicfoundation/slang": "1.3.8",
+                "@solidity-parser/parser": "^0.20.2",
+                "semver": "^7.8.5"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "peerDependencies": {
-                "prettier": ">=2.3.0"
+                "prettier": ">=3.0.0"
             }
         },
         "node_modules/promise-throttle": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "mocha": "^11.7.6",
         "operator-filter-registry": "^1.3.1",
         "prettier": "^3.8.1",
-        "prettier-plugin-solidity": "^1.1.3",
+        "prettier-plugin-solidity": "^2.4.1",
         "solhint": "^6.1.0",
         "solhint-plugin-prettier": "^0.1.0"
     },
@@ -64,5 +64,10 @@
     "homepage": "https://github.com/FrankNFT-labs/ERC721F#readme",
     "engines": {
         "node": ">=24"
+    },
+    "overrides": {
+        "solhint-plugin-prettier": {
+            "prettier-plugin-solidity": "$prettier-plugin-solidity"
+        }
     }
 }


### PR DESCRIPTION
Supersedes #164, which could not merge on its own.

## Why #164 failed

Two independent blockers, neither fixable by a rebase:

1. **`npm ci` ERESOLVE.** `solhint-plugin-prettier@0.1.0` is the latest release and still caps its peer at `prettier-plugin-solidity@^1.0.0`. No published version accepts 2.x.
2. **`npm run lint` hard-errors.** The 2.x major dropped the `solidity-parse` parser that `.prettierrc` pins, replacing it with `slang` (new default) and `antlr` (the legacy 1.x engine). A straight version bump leaves solhint throwing `ConfigError: Couldn't resolve parser "solidity-parse"`.

The second one is the reason this needed a real PR — CI never caught it, because CI does not run solhint. It would have surfaced as a broken pre-commit hook for everyone.

## What this does

- Bumps `prettier-plugin-solidity` to `^2.4.1`
- Adds an npm `overrides` entry pinning `solhint-plugin-prettier`'s peer to the version we already depend on, so it dedupes onto 2.4.1 instead of installing a second 1.x copy
- Points `.prettierrc` at the `slang` parser
- Reformats the 27 affected `.sol` files

The `.sol` diff is line-breaking only. Import paths and every other token are byte-identical — verified by extracting and comparing the module-specifier sets on both sides of the diff.

## Verification

| Gate | Result |
|---|---|
| `npm ci` | clean, no ERESOLVE |
| `npm ls` | `solhint-plugin-prettier` → `prettier-plugin-solidity@2.4.1 deduped` |
| `npx solhint '**/*.sol'` | **0 errors**, 107 warnings (all pre-existing: 97 `func-name-mixedcase`, 10 `ordering`) |
| `prettier/prettier` rule still enforcing | confirmed — injected a deliberate misformat, rule fired with 1 error |
| `npx hardhat compile` | 62 files, solc 0.8.24 |
| `npm test` | 314 passing, 1 pending |
| `forge build` / `forge test` | 136 passed, 0 failed |
| husky pre-commit | full lint-staged pipeline passed |

The negative test matters most here: an override that silences a peer warning can leave the rule silently inert. It doesn't — the rule still catches bad formatting.

Closes #164