### PR TITLE
fix(test): correct over-deep relative imports in foundry utils tests

### DIFF
--- a/test/foundry/utils/AddressUtils.t.sol
+++ b/test/foundry/utils/AddressUtils.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20 <0.9.0;
 
-import "../../../../lib/forge-std/src/Test.sol";
-import "../../../../contracts/mocks/AddressUtilsMock.sol";
+import "../../../lib/forge-std/src/Test.sol";
+import "../../../contracts/mocks/AddressUtilsMock.sol";
 
 /**
  * @title AddressUtilsTest

--- a/test/foundry/utils/AllowList.t.sol
+++ b/test/foundry/utils/AllowList.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20 <0.9.0;
 
-import "../../../../lib/forge-std/src/Test.sol";
-import "../../../../contracts/mocks/AllowListMock.sol";
+import "../../../lib/forge-std/src/Test.sol";
+import "../../../contracts/mocks/AllowListMock.sol";
 
 /**
  * @title AllowListTest

--- a/test/foundry/utils/AllowListWithAmount.t.sol
+++ b/test/foundry/utils/AllowListWithAmount.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20 <0.9.0;
 
-import "../../../../lib/forge-std/src/Test.sol";
-import "../../../../contracts/mocks/AllowListWithAmountMock.sol";
+import "../../../lib/forge-std/src/Test.sol";
+import "../../../contracts/mocks/AllowListWithAmountMock.sol";
 
 /**
  * @title AllowListWithAmountTest

--- a/test/foundry/utils/MultiOperable.t.sol
+++ b/test/foundry/utils/MultiOperable.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20 <0.9.0;
 
-import "../../../../lib/forge-std/src/Test.sol";
-import "../../../../contracts/mocks/MultiOperableMock.sol";
+import "../../../lib/forge-std/src/Test.sol";
+import "../../../contracts/mocks/MultiOperableMock.sol";
 
 /**
  * @title MultiOperableTest

--- a/test/foundry/utils/Operable.t.sol
+++ b/test/foundry/utils/Operable.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20 <0.9.0;
 
-import "../../../../lib/forge-std/src/Test.sol";
-import "../../../../contracts/mocks/OperableMock.sol";
+import "../../../lib/forge-std/src/Test.sol";
+import "../../../contracts/mocks/OperableMock.sol";
 
 /**
  * @title OperableTest

--- a/test/foundry/utils/Payable.t.sol
+++ b/test/foundry/utils/Payable.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20 <0.9.0;
 
-import "../../../../lib/forge-std/src/Test.sol";
-import "../../../../contracts/mocks/PayableMock.sol";
+import "../../../lib/forge-std/src/Test.sol";
+import "../../../contracts/mocks/PayableMock.sol";
 
 /**
  * @title PayableTest

--- a/test/foundry/utils/Random.t.sol
+++ b/test/foundry/utils/Random.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20 <0.9.0;
 
-import "../../../../lib/forge-std/src/Test.sol";
-import "../../../../contracts/mocks/RandomMock.sol";
+import "../../../lib/forge-std/src/Test.sol";
+import "../../../contracts/mocks/RandomMock.sol";
 
 /**
  * @title RandomTest

--- a/test/foundry/utils/Verify.t.sol
+++ b/test/foundry/utils/Verify.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20 <0.9.0;
 
-import "../../../../lib/forge-std/src/Test.sol";
-import "../../../../contracts/mocks/VerifyMock.sol";
-import "../../../../contracts/mocks/ERC721FMock.sol";
+import "../../../lib/forge-std/src/Test.sol";
+import "../../../contracts/mocks/VerifyMock.sol";
+import "../../../contracts/mocks/ERC721FMock.sol";
 
 /**
  * @title VerifyTest


### PR DESCRIPTION
## What broke

Every main build since c2e5bf9 (#168) fails the **Foundry Tests** job. The dependabot bumps were innocent — none of #168/#169/#170/#172 touch a `.sol` file. What changed is CI's toolchain: `foundry-toolchain` installs `version: stable`, and stable moved to **forge 1.8.0**, whose post-build **solar** lint engine rejects imports that escape the repo root. The log even says `compilation itself succeeded` — only the lint step fails.

## Root cause

The 8 test files in `test/foundry/utils/` sit **three** directories deep but import with **four** `../` levels:

```solidity
// test/foundry/utils/AllowList.t.sol (depth 3)
import "../../../../lib/forge-std/src/Test.sol";   // resolves via the repo's PARENT dir
```

The path round-trips through the parent directory and lands back inside the repo, so solc always tolerated it. Solar doesn't. Audit across all 42 relative imports in `test/foundry/`: exactly **17** have the wrong depth — matching solar's `17 errors` one for one. Deeper test dirs (`token/ERC721/`, `extensions/`) already use the correct count.

## Fix

Trim the 17 imports to three levels. 8 files, 17 lines, imports only.

## Verification

| Gate | Before | After |
|---|---|---|
| `forge lint test/foundry` | errors | **0 errors** |
| `forge build --force` | — | exit 0 |
| `forge test` | — | **136 passed, 0 failed** |
| `npm test` | — | **314 passing** |
| `prettier --check` / solhint | — | clean |
| husky pre-commit | — | passed |

(Local repro on forge 1.5.1 via `forge lint`; CI's 1.8.0 enforces the same check at build time.)

## Note for reviewers

`version: stable` in the workflow means the Foundry toolchain silently upgrades under us — this failure appeared with zero repo changes. Consider pinning (e.g. `version: v1.8.0`) and letting dependabot's github-actions ecosystem propose upgrades explicitly.