### PR TITLE
ci: pin foundry-toolchain to v1.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
 
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
+              with:
+                  # Pinned: `stable` upgrades under us (1.8.0 broke main with
+                  # zero repo changes). Bump deliberately, after a local run.
+                  version: v1.8.0
 
             - name: Build contracts
               run: forge build


### PR DESCRIPTION
Follow-up to #173.

`foundry-toolchain` had no `version` input, defaulting to `stable` — so the toolchain upgrades under us on Foundry's release schedule, not ours. forge **v1.8.0** was published 27-08-2026 12:30 UTC and every main build failed from that afternoon on, with zero repo changes, via its new post-build solar lint.

This pins `version: v1.8.0` — the release main is currently green on (verified: release tag exists on foundry-rs/foundry; #173 passed CI on exactly this version).

**Trade-off, stated plainly:** dependabot's `github-actions` ecosystem bumps the action ref (`foundry-toolchain@v1`), *not* this `version:` input — so Foundry upgrades become manual. That's the point: run the new forge locally first (`foundryup --install <ver>`, `forge build && forge test`), then bump the pin in the same PR as any required fixes.

1 file, +4 lines. YAML validated.